### PR TITLE
Add started flag to threads

### DIFF
--- a/conn.c
+++ b/conn.c
@@ -959,8 +959,8 @@ xbee_err xbee_conCallbackProd(struct xbee_con *con) {
 		xbee_err ret2;
 		
 #warning TODO - there is a gap here, needs a mutex
-		if (con->callbackThread->active) return XBEE_ENONE;
-		
+		if (con->callbackThread->active || !con->callbackThread->started) return XBEE_ENONE;
+
 		if ((ret = xbee_threadJoin(con->xbee, con->callbackThread, &ret2)) != XBEE_ENONE) return ret;
 		con->callbackThread = NULL;
 		if (ret2 != XBEE_ENONE) {

--- a/thread.c
+++ b/thread.c
@@ -64,6 +64,7 @@ void *threadFunc(struct xbee_threadInfo *thread) {
 		restart = 1;
 	}
 	
+	thread->started = 1;
 	do {
 		xbee_log(15, "starting thread %p, function %s()...", thread, thread->funcName);
 	
@@ -114,6 +115,7 @@ xbee_err _xbee_threadStart(struct xbee *xbee, struct xbee_threadInfo **retThread
 	thread->run = 1;
 	thread->detached = detach;
 	thread->restartDelay = restartDelay;
+	thread->started = 0;
 	xsys_sem_init(&thread->mutexSem);
 
 	if ((xsys_thread_create(&thread->tid, (void*(*)(void *))threadFunc, thread)) != 0) {

--- a/thread.h
+++ b/thread.h
@@ -29,6 +29,7 @@ struct xbee_threadInfo {
 	int detached;/* TRUE will cause the thread to free the info block before it returns */
 	int running; /* TRUE means that the function is actually running */
 	int active;  /* TRUE means that the thread is alive */
+	int started; /* TRUE means that the thread has started and is ready to run its function */
 
 	time_t restartDelay;
 	xsys_thread tid;


### PR DESCRIPTION
Fixes an issue where there will be a 5 second delay between packets being processed by the `rxHandler` thread if it tries to process a packet associated with a callback before the callback thread has a chance to start running (which can happen with a single processor system).  The call to `xbee_conCallbackProd` would occur before the thread's `active` state is set to 1 by `threadFunc` so it would try to join on the thread and block.  When the callback thread gets a chance to run, it will process the packet that was added and then wait for 5 seconds for another packet (which cannot happen since the `rxHandler` thread is blocked) before exiting.  Once the callback thread exits, the join returns and the `rxHandler` thread becomes unblocked.  This should fix the issue by giving the callback thread a chance to get running before we deem that another callback thread must be started.
