### PR TITLE
Implement stale frame timeout.

### DIFF
--- a/frame.h
+++ b/frame.h
@@ -38,6 +38,9 @@ struct xbee_frame {
 	unsigned char id;
 	unsigned char retVal;
 	unsigned char status; /* this used the XBEE_FRAME_STATUS_* bitfield - zero means unused */
+#ifdef XBEE_FRAME_TIMEOUT_ENABLED
+	struct timespec timeout;
+#endif
 };
 
 struct xbee_frameBlock {


### PR DESCRIPTION
Allows the reuse of stale frames (as determined by a timeout) as discussed here: https://groups.google.com/d/msg/libxbee/M-N3N24F4HM/cpFTyl3CCwAJ