### PR TITLE
Default to O_CLOEXEC on for linux.

### DIFF
--- a/xsys_linux.c
+++ b/xsys_linux.c
@@ -90,7 +90,7 @@ int xsys_serialSetup(struct xbee_serialInfo *info) {
 #endif
 	}
 	
-	if ((info->dev.fd = open(info->device, O_RDWR | O_NOCTTY | O_SYNC)) == -1) {
+	if ((info->dev.fd = open(info->device, O_RDWR | O_NOCTTY | O_SYNC | O_CLOEXEC)) == -1) {
 		perror("open()");
 		return XBEE_EIO;
 	}


### PR DESCRIPTION
This adds the O_CLOEXEC flag when opening the FD in Linux to prevent child processes from unexpectedly inheriting the open FD.  I would guess that the flag could be added to the Darwin code too, but I abstained since I am not able to test in that environment.