### PR TITLE
Use const in the C++ interface wherever this is possible

### DIFF
--- a/include/xbee.h
+++ b/include/xbee.h
@@ -219,7 +219,7 @@ EXPORT void xbee_fini(void);
 typedef void (*xbee_t_eofCallback)(struct xbee *xbee, void *rxInfo);
 
 EXPORT void xbee_freeMemory(void *ptr); /* <-- this is for STUPID windows */
-EXPORT xbee_err xbee_validate(struct xbee *xbee);
+EXPORT xbee_err xbee_validate(const struct xbee *xbee);
 EXPORT xbee_err xbee_setup(struct xbee **retXbee, const char *mode, ...);
 EXPORT xbee_err xbee_vsetup(struct xbee **retXbee, const char *mode, va_list ap);
 EXPORT xbee_err xbee_attachEOFCallback(struct xbee *xbee, xbee_t_eofCallback eofCallback);
@@ -232,7 +232,7 @@ EXPORT xbee_err xbee_dataGet(struct xbee *xbee, void **curData);
 /* ######################################################################### */
 /* --- mode.c --- */
 EXPORT xbee_err xbee_modeGetList(char ***retList);
-EXPORT xbee_err xbee_modeGet(struct xbee *xbee, const char **mode);
+EXPORT xbee_err xbee_modeGet(const struct xbee *xbee, const char **mode);
 
 
 /* ######################################################################### */

--- a/include/xbeep.h
+++ b/include/xbeep.h
@@ -83,16 +83,16 @@ namespace libxbee {
 	
 	class EXPORT Con {
 		public:
-			EXPORT explicit Con(XBee &parent, std::string type, struct xbee_conAddress *address = NULL);
+			EXPORT explicit Con(XBee &parent, const std::string &type, struct xbee_conAddress *address = NULL);
 			EXPORT ~Con(void);
 			
-			EXPORT unsigned char operator<< (std::string data);
-			EXPORT unsigned char operator<< (std::vector<unsigned char> data);
-			EXPORT unsigned char operator<< (std::vector<char> data);
-			EXPORT void operator>> (Pkt &pkt);
-			EXPORT void operator>> (std::string &data);
-			EXPORT void operator>> (std::vector<unsigned char> &data);
-			EXPORT void operator>> (std::vector<char> &data);
+			EXPORT unsigned char operator<< (const std::string &data) const;
+			EXPORT unsigned char operator<< (const std::vector<unsigned char> &data) const;
+			EXPORT unsigned char operator<< (const std::vector<char> &data) const;
+			EXPORT void operator>> (Pkt &pkt) const;
+			EXPORT void operator>> (std::string &data) const;
+			EXPORT void operator>> (std::vector<unsigned char> &data) const;
+			EXPORT void operator>> (std::vector<char> &data) const;
 			
 		private:
 			friend class XBee;
@@ -104,17 +104,18 @@ namespace libxbee {
 			virtual void xbee_conCallback(Pkt **pkt);
 			
 		public:
+			EXPORT const struct xbee_con *getHnd(void) const;
 			EXPORT struct xbee_con *getHnd(void);
-			EXPORT unsigned char Tx(std::string data);
-			EXPORT unsigned char Tx(std::vector<unsigned char> data);
-			EXPORT unsigned char Tx(std::vector<char> data);
-			EXPORT unsigned char Tx(const unsigned char *buf, int len);
-			EXPORT unsigned char Tx(unsigned char *frameId, std::string data);
-			EXPORT unsigned char Tx(unsigned char *frameId, std::vector<unsigned char> data);
-			EXPORT unsigned char Tx(unsigned char *frameId, std::vector<char> data);
-			EXPORT unsigned char Tx(unsigned char *frameId, const unsigned char *buf, int len);
-			EXPORT void Rx(Pkt &pkt, int *remainingPackets = NULL);
-			EXPORT int RxAvailable(void);
+			EXPORT unsigned char Tx(const std::string &data) const;
+			EXPORT unsigned char Tx(const std::vector<unsigned char> &data) const;
+			EXPORT unsigned char Tx(const std::vector<char> &data) const;
+			EXPORT unsigned char Tx(const unsigned char *buf, int len) const;
+			EXPORT unsigned char Tx(unsigned char *frameId, const std::string &data) const;
+			EXPORT unsigned char Tx(unsigned char *frameId, const std::vector<unsigned char> &data) const;
+			EXPORT unsigned char Tx(unsigned char *frameId, const std::vector<char> &data) const;
+			EXPORT unsigned char Tx(unsigned char *frameId, const unsigned char *buf, int len) const;
+			EXPORT void Rx(Pkt &pkt, int *remainingPackets = NULL) const;
+			EXPORT int RxAvailable(void) const;
 			
 			EXPORT void purge(void);
 			
@@ -144,39 +145,41 @@ namespace libxbee {
 			EXPORT ~Pkt(void);
 			
 			EXPORT unsigned char operator[] (int index);
-			EXPORT void operator<< (Con &con);
-			EXPORT void operator>> (std::string &data);
-			EXPORT void operator>> (std::vector<unsigned char> &data);
-			EXPORT void operator>> (std::vector<char> &data);
+			EXPORT void operator<< (const Con &con);
+			EXPORT void operator>> (std::string &data) const;
+			EXPORT void operator>> (std::vector<unsigned char> &data) const;
+			EXPORT void operator>> (std::vector<char> &data) const;
 			
 		private:
 			struct xbee_pkt *pkt;
 			
 		public:
+			EXPORT const struct xbee_pkt *getHnd(void) const;
 			EXPORT struct xbee_pkt *getHnd(void);
 			EXPORT void setHnd(struct xbee_pkt *pkt);
 			
 			/* when calling this function, YOU become responsible for freeing the previously held packet */
 			EXPORT struct xbee_pkt *dropHnd(void);
 			
-			EXPORT int size(void);
+			EXPORT int size(void) const;
 			
-			EXPORT std::string getData(void);
-			EXPORT std::vector<unsigned char> getVector(void);
-			EXPORT std::vector<char> getVector2(void);
-			/* use these three with care... */
-			EXPORT void *getData(const char *key);
-			EXPORT void *getData(const char *key, int id);
-			EXPORT void *getData(const char *key, int id, int index);
-			
-			EXPORT std::string getATCommand(void);
-			
-			EXPORT int getAnalog(int channel);
-			EXPORT int getAnalog(int channel, int index);
-			EXPORT bool getDigital(int channel);
-			EXPORT bool getDigital(int channel, int index);
+			EXPORT std::string getData(void) const;
+			EXPORT std::vector<unsigned char> getVector(void) const;
+			EXPORT std::vector<char> getVector2(void) const;
 
-			EXPORT unsigned char getRssi(void);
+			/* use these three with care... */
+			EXPORT void *getData(const char *key) const ;
+			EXPORT void *getData(const char *key, int id) const;
+			EXPORT void *getData(const char *key, int id, int index) const;
+			
+			EXPORT std::string getATCommand(void) const;
+			
+			EXPORT int getAnalog(int channel) const;
+			EXPORT int getAnalog(int channel, int index) const;
+			EXPORT bool getDigital(int channel) const;
+			EXPORT bool getDigital(int channel, int index) const;
+
+			EXPORT unsigned char getRssi(void) const;
 	};
 };
 

--- a/include/xbeep.h
+++ b/include/xbeep.h
@@ -56,9 +56,9 @@ namespace libxbee {
 	
 	class EXPORT XBee {
 		public:
-			EXPORT explicit XBee(std::string mode);
-			EXPORT explicit XBee(std::string mode, std::string device, int baudrate);
-			EXPORT explicit XBee(std::string mode, va_list ap);
+			EXPORT explicit XBee(const std::string &mode);
+			EXPORT explicit XBee(const std::string &mode, const std::string &device, int baudrate);
+			EXPORT explicit XBee(const std::string &mode, va_list ap);
 			EXPORT ~XBee(void);
 			
 		private:
@@ -67,16 +67,18 @@ namespace libxbee {
 			
 		public:
 			EXPORT struct xbee *getHnd(void);
+			EXPORT const struct xbee *getHnd(void) const;
 			EXPORT void conRegister(Con *con);
 			EXPORT void conUnregister(Con *con);
-			EXPORT Con *conLocate(struct xbee_con *con);
-			EXPORT std::list<std::string> getConTypes(void);
+			EXPORT const Con *conLocate(const struct xbee_con *con) const;
+			EXPORT Con *conLocate(const struct xbee_con *con);
+			EXPORT std::list<std::string> getConTypes(void) const;
 			
-			EXPORT std::string mode(void);
+			EXPORT std::string mode(void) const;
 			
-			EXPORT void setLogTarget(FILE *f);
-			EXPORT void setLogLevel(int level);
-			EXPORT int getLogLevel(void);
+			EXPORT void setLogTarget(FILE *f) const;
+			EXPORT void setLogLevel(int level) const;
+			EXPORT int getLogLevel(void) const;
 	};
 	
 	class EXPORT Con {

--- a/ll.c
+++ b/ll.c
@@ -33,7 +33,7 @@ struct xbee_ll_info {
 	void *item;
 };
 
-xbee_err __xbee_ll_get_item(void *list, void *item, struct xbee_ll_info **retItem, int needMutex);
+xbee_err __xbee_ll_get_item(void *list, const void *item, struct xbee_ll_info **retItem, int needMutex);
 
 /* this file is scary, sorry it isn't commented... i nearly broke myself writing it
    maybe oneday soon i'll be brave and put some commends down */
@@ -284,7 +284,7 @@ xbee_err _xbee_ll_get_tail(void *list, void **retItem, int needMutex) {
 }
 
 /* returns struct xbee_ll_info* or NULL - don't touch the pointer if you don't know what you're doing ;) */
-xbee_err __xbee_ll_get_item(void *list, void *item, struct xbee_ll_info **retItem, int needMutex) {
+xbee_err __xbee_ll_get_item(void *list, const void *item, struct xbee_ll_info **retItem, int needMutex) {
 	struct xbee_ll_head *h;
 	struct xbee_ll_info *i;
 	if (!list) return XBEE_EMISSINGPARAM;
@@ -302,7 +302,7 @@ xbee_err __xbee_ll_get_item(void *list, void *item, struct xbee_ll_info **retIte
 	if (!i) return XBEE_ENOTEXISTS;
 	return XBEE_ENONE;
 }
-xbee_err _xbee_ll_get_item(void *list, void *item, int needMutex) {
+xbee_err _xbee_ll_get_item(void *list, const void *item, int needMutex) {
 	return __xbee_ll_get_item(list, item, NULL, needMutex);
 }
 

--- a/ll.h
+++ b/ll.h
@@ -67,7 +67,7 @@ xbee_err _xbee_ll_add_before(void *list, void *ref, void *item, int needMutex);
 
 xbee_err _xbee_ll_get_head(void *list, void **retItem, int needMutex);
 xbee_err _xbee_ll_get_tail(void *list, void **retItem, int needMutex);
-xbee_err _xbee_ll_get_item(void *list, void *item, int needMutex);
+xbee_err _xbee_ll_get_item(void *list, const void *item, int needMutex);
 xbee_err _xbee_ll_get_next(void *list, void *ref, void **retItem, int needMutex);
 xbee_err _xbee_ll_get_prev(void *list, void *ref, void **retItem, int needMutex);
 xbee_err _xbee_ll_get_index(void *list, unsigned int index, void **retItem, int needMutex);

--- a/mode.c
+++ b/mode.c
@@ -213,7 +213,7 @@ EXPORT xbee_err xbee_modeGetList(char ***retList) {
 	return XBEE_ENONE;
 }
 
-EXPORT xbee_err xbee_modeGet(struct xbee *xbee, const char **mode) {
+EXPORT xbee_err xbee_modeGet(const struct xbee *xbee, const char **mode) {
 	if (!xbee || !mode) return XBEE_EMISSINGPARAM;
 #ifndef XBEE_DISABLE_STRICT_OBJECTS
 	if (xbee_validate(xbee) != XBEE_ENONE) return XBEE_EINVAL;

--- a/xbee.c
+++ b/xbee.c
@@ -46,7 +46,7 @@ EXPORT void xbee_freeMemory(void *ptr) {
 
 /* ######################################################################### */
 
-EXPORT xbee_err xbee_validate(struct xbee *xbee) {
+EXPORT xbee_err xbee_validate(const struct xbee *xbee) {
 	if (xbee_ll_get_item(xbeeList, xbee) != XBEE_ENONE) return XBEE_EINVAL;
 	return XBEE_ENONE;
 }

--- a/xbeep.cpp
+++ b/xbeep.cpp
@@ -164,7 +164,7 @@ EXPORT int libxbee::XBee::getLogLevel(void) const {
 
 /* ========================================================================== */
 
-EXPORT libxbee::Con::Con(XBee &parent, std::string type, struct xbee_conAddress *address) : parent(parent) {
+EXPORT libxbee::Con::Con(XBee &parent, const std::string &type, struct xbee_conAddress *address) : parent(parent) {
 	xbee_err ret;
 	
 	if ((xbee = parent.getHnd()) == NULL) throw(XBEE_EINVAL);
@@ -188,61 +188,62 @@ EXPORT libxbee::Con::~Con(void) {
 
 EXPORT void libxbee::Con::xbee_conCallback(Pkt **pkt) { }
 
-EXPORT unsigned char libxbee::Con::operator<< (std::string data) {
+EXPORT unsigned char libxbee::Con::operator<< (const std::string &data) const {
 	return Tx(data);
 }
-EXPORT unsigned char libxbee::Con::operator<< (std::vector<unsigned char> data) {
+EXPORT unsigned char libxbee::Con::operator<< (const std::vector<unsigned char> &data) const {
 	return Tx(data);
 }
-EXPORT unsigned char libxbee::Con::operator<< (std::vector<char> data) {
+EXPORT unsigned char libxbee::Con::operator<< (const std::vector<char> &data) const {
 	return Tx(data);
 }
-EXPORT void libxbee::Con::operator>> (Pkt &pkt) {
+EXPORT void libxbee::Con::operator>> (Pkt &pkt) const {
 	return Rx(pkt);
 }
-EXPORT void libxbee::Con::operator>> (std::string &data) {
+EXPORT void libxbee::Con::operator>> (std::string &data) const {
 	libxbee::Pkt p;
 	p << *this;
 	p >> data;
 }
-EXPORT void libxbee::Con::operator>> (std::vector<unsigned char> &data) {
+EXPORT void libxbee::Con::operator>> (std::vector<unsigned char> &data) const {
 	libxbee::Pkt p;
 	p << *this;
 	p >> data;
 }
-EXPORT void libxbee::Con::operator>> (std::vector<char> &data) {
+EXPORT void libxbee::Con::operator>> (std::vector<char> &data) const {
 	libxbee::Pkt p;
 	p << *this;
 	p >> data;
 }
-
-EXPORT struct xbee_con *libxbee::Con::getHnd(void) {
+EXPORT const struct xbee_con *libxbee::Con::getHnd(void) const {
 	if (con == NULL) throw(XBEE_ESHUTDOWN);
 	return con;
 }
-
-EXPORT unsigned char libxbee::Con::Tx(std::string data) {
+EXPORT struct xbee_con *libxbee::Con::getHnd(void) {
+        return const_cast<struct xbee_con *>(static_cast<const libxbee::Con *>(this)->getHnd());
+}
+EXPORT unsigned char libxbee::Con::Tx(const std::string &data) const {
 	return Tx((unsigned char *)NULL, (const unsigned char *)data.c_str(), data.size());
 }
-EXPORT unsigned char libxbee::Con::Tx(std::vector<unsigned char> data) {
+EXPORT unsigned char libxbee::Con::Tx(const std::vector<unsigned char> &data) const {
 	return Tx((unsigned char *)NULL, &(data[0]), data.size());
 }
-EXPORT unsigned char libxbee::Con::Tx(std::vector<char> data) {
+EXPORT unsigned char libxbee::Con::Tx(const std::vector<char> &data) const {
 	return Tx((unsigned char *)NULL, (unsigned char *)&(data[0]), data.size());
 }
-EXPORT unsigned char libxbee::Con::Tx(const unsigned char *buf, int len) {
+EXPORT unsigned char libxbee::Con::Tx(const unsigned char *buf, int len) const {
 	return Tx((unsigned char *)NULL, buf, len);
 }
-EXPORT unsigned char libxbee::Con::Tx(unsigned char *frameId, std::string data) {
+EXPORT unsigned char libxbee::Con::Tx(unsigned char *frameId, const std::string &data) const {
 	return Tx(frameId, (const unsigned char *)data.c_str(), data.size());
 }
-EXPORT unsigned char libxbee::Con::Tx(unsigned char *frameId, std::vector<unsigned char> data) {
+EXPORT unsigned char libxbee::Con::Tx(unsigned char *frameId, const std::vector<unsigned char> &data) const {
 	return Tx(frameId, &(data[0]), data.size());
 }
-EXPORT unsigned char libxbee::Con::Tx(unsigned char *frameId, std::vector<char> data) {
+EXPORT unsigned char libxbee::Con::Tx(unsigned char *frameId, const std::vector<char> &data) const {
 	return Tx(frameId, (unsigned char *)&(data[0]), data.size());
 }
-EXPORT unsigned char libxbee::Con::Tx(unsigned char *frameId, const unsigned char *buf, int len) {
+EXPORT unsigned char libxbee::Con::Tx(unsigned char *frameId, const unsigned char *buf, int len) const {
 	unsigned char retVal;
 	xbee_err ret;
 	
@@ -253,7 +254,7 @@ EXPORT unsigned char libxbee::Con::Tx(unsigned char *frameId, const unsigned cha
 	throw(ret);
 }
 
-EXPORT void libxbee::Con::Rx(Pkt &pkt, int *remainingPackets) {
+EXPORT void libxbee::Con::Rx(Pkt &pkt, int *remainingPackets) const {
 	struct xbee_pkt *raw_pkt;
 	xbee_err ret;
 	
@@ -262,7 +263,7 @@ EXPORT void libxbee::Con::Rx(Pkt &pkt, int *remainingPackets) {
 	
 	pkt.setHnd(raw_pkt);
 }
-EXPORT int libxbee::Con::RxAvailable(void) {
+EXPORT int libxbee::Con::RxAvailable(void) const {
 	int remainingPackets;
 	xbee_err ret;
 
@@ -359,24 +360,26 @@ EXPORT unsigned char libxbee::Pkt::operator[] (int index) {
 	if (index > size()) throw(XBEE_ERANGE);
 	return pkt->data[index];
 }
-EXPORT void libxbee::Pkt::operator<< (Con &con) {
+EXPORT void libxbee::Pkt::operator<< (const Con &con) {
 	con.Rx(*this);
 }
-EXPORT void libxbee::Pkt::operator>> (std::string &data) {
+EXPORT void libxbee::Pkt::operator>> (std::string &data) const{
 	data = getData();
 }
-EXPORT void libxbee::Pkt::operator>> (std::vector<unsigned char> &data) {
+EXPORT void libxbee::Pkt::operator>> (std::vector<unsigned char> &data) const {
 	data = getVector();
 }
-EXPORT void libxbee::Pkt::operator>> (std::vector<char> &data) {
+EXPORT void libxbee::Pkt::operator>> (std::vector<char> &data) const {
 	data = getVector2();
 }
 
-EXPORT int libxbee::Pkt::size(void) {
+EXPORT int libxbee::Pkt::size(void) const {
 	if (pkt == NULL) throw(XBEE_EINVAL);
 	return pkt->dataLen;
 }
-
+EXPORT const struct xbee_pkt *libxbee::Pkt::getHnd(void) const {
+	return pkt;
+}
 EXPORT struct xbee_pkt *libxbee::Pkt::getHnd(void) {
 	return pkt;
 }
@@ -391,30 +394,30 @@ EXPORT struct xbee_pkt *libxbee::Pkt::dropHnd(void) {
 	return t;
 }
 
-EXPORT std::string libxbee::Pkt::getData(void) {
+EXPORT std::string libxbee::Pkt::getData(void) const {
 	return std::string((char*)pkt->data, pkt->dataLen);
 }
-EXPORT std::vector<unsigned char> libxbee::Pkt::getVector(void) {
+EXPORT std::vector<unsigned char> libxbee::Pkt::getVector(void) const {
 	std::vector<unsigned char> data;
 	for (int i = 0; i < pkt->dataLen; i++) {
 		data.push_back(pkt->data[i]);
 	}
 	return data;
 }
-EXPORT std::vector<char> libxbee::Pkt::getVector2(void) {
+EXPORT std::vector<char> libxbee::Pkt::getVector2(void) const {
 	std::vector<char> data;
 	for (int i = 0; i < pkt->dataLen; i++) {
 		data.push_back((char)pkt->data[i]);
 	}
 	return data;
 }
-EXPORT void *libxbee::Pkt::getData(const char *key) {
+EXPORT void *libxbee::Pkt::getData(const char *key) const {
 	return getData(key, 0, 0);
 }
-EXPORT void *libxbee::Pkt::getData(const char *key, int id) {
+EXPORT void *libxbee::Pkt::getData(const char *key, int id) const {
 	return getData(key, id, 0);
 }
-EXPORT void *libxbee::Pkt::getData(const char *key, int id, int index) {
+EXPORT void *libxbee::Pkt::getData(const char *key, int id, int index) const {
 	xbee_err ret;
 	void *p;
 	
@@ -422,16 +425,16 @@ EXPORT void *libxbee::Pkt::getData(const char *key, int id, int index) {
 	return p;
 }
 
-EXPORT std::string libxbee::Pkt::getATCommand(void) {
+EXPORT std::string libxbee::Pkt::getATCommand(void) const {
 	std::string type(pkt->conType);
 	if (type != "Local AT" && type != "Remote AT") throw(XBEE_EINVAL);
 	return std::string((char*)pkt->atCommand, 2);
 }
 
-EXPORT int libxbee::Pkt::getAnalog(int channel) {
+EXPORT int libxbee::Pkt::getAnalog(int channel) const {
 	return getAnalog(channel, 0);
 }
-EXPORT int libxbee::Pkt::getAnalog(int channel, int index) {
+EXPORT int libxbee::Pkt::getAnalog(int channel, int index) const {
 	xbee_err ret;
 	int value;
 	
@@ -439,10 +442,10 @@ EXPORT int libxbee::Pkt::getAnalog(int channel, int index) {
 	return value;
 }
 
-EXPORT bool libxbee::Pkt::getDigital(int channel) {
+EXPORT bool libxbee::Pkt::getDigital(int channel) const {
 	return getDigital(channel, 0);
 }
-EXPORT bool libxbee::Pkt::getDigital(int channel, int index) {
+EXPORT bool libxbee::Pkt::getDigital(int channel, int index) const {
 	xbee_err ret;
 	int value;
 	
@@ -450,6 +453,6 @@ EXPORT bool libxbee::Pkt::getDigital(int channel, int index) {
 	return (bool)!!value;
 }
 
-EXPORT unsigned char libxbee::Pkt::getRssi(void) {
+EXPORT unsigned char libxbee::Pkt::getRssi(void) const {
 	return pkt->rssi;
 }

--- a/xbeep.cpp
+++ b/xbeep.cpp
@@ -52,21 +52,21 @@ EXPORT std::list<std::string> libxbee::getModes(void) {
 
 /* ========================================================================== */
 
-EXPORT libxbee::XBee::XBee(std::string mode) {
+EXPORT libxbee::XBee::XBee(const std::string &mode) {
 	xbee_err ret;
 	
 	if ((ret = xbee_setup(&xbee, mode.c_str())) != XBEE_ENONE) throw(ret);
 	
 	xbeeList.push_back(this);
 }
-EXPORT libxbee::XBee::XBee(std::string mode, std::string device, int baudrate) {
+EXPORT libxbee::XBee::XBee(const std::string &mode, const std::string &device, int baudrate) {
 	xbee_err ret;
 	
 	if ((ret = xbee_setup(&xbee, mode.c_str(), device.c_str(), baudrate)) != XBEE_ENONE) throw(ret);
 	
 	xbeeList.push_back(this);
 }
-EXPORT libxbee::XBee::XBee(std::string mode, va_list ap) {
+EXPORT libxbee::XBee::XBee(const std::string &mode, va_list ap) {
 	xbee_err ret;
 	
 	if ((ret = xbee_vsetup(&xbee, mode.c_str(), ap)) != XBEE_ENONE) throw(ret);
@@ -90,6 +90,11 @@ EXPORT libxbee::XBee::~XBee(void) {
 EXPORT struct xbee *libxbee::XBee::getHnd(void) {
 	return xbee;
 }
+
+EXPORT const struct xbee *libxbee::XBee::getHnd(void) const {
+	return xbee;
+}
+
 EXPORT void libxbee::XBee::conRegister(Con *con) {
 	xbee_err ret;
 	if ((ret = xbee_conValidate(con->getHnd())) != XBEE_ENONE) throw(ret);
@@ -99,15 +104,22 @@ EXPORT void libxbee::XBee::conRegister(Con *con) {
 EXPORT void libxbee::XBee::conUnregister(Con *con) {
 	conList.remove(con);
 }
-EXPORT libxbee::Con *libxbee::XBee::conLocate(struct xbee_con *con) {
-	std::list<Con*>::iterator i;
+
+EXPORT const libxbee::Con *libxbee::XBee::conLocate(const struct xbee_con *con) const {
+	std::list<Con*>::const_iterator i;
 	for (i = conList.begin(); i != conList.end(); i++) {
 		if ((*i)->getHnd() == con) return (*i);
 	}
 	return NULL;
 }
-
-EXPORT std::list<std::string> libxbee::XBee::getConTypes(void) {
+EXPORT libxbee::Con *libxbee::XBee::conLocate(const struct xbee_con *con) {
+	std::list<Con*>::const_iterator i;
+	for (i = conList.begin(); i != conList.end(); i++) {
+		if ((*i)->getHnd() == con) return (*i);
+	}
+	return NULL;
+}
+EXPORT std::list<std::string> libxbee::XBee::getConTypes(void) const {
 	xbee_err ret;
 	char **types;
 	int i;
@@ -122,7 +134,7 @@ EXPORT std::list<std::string> libxbee::XBee::getConTypes(void) {
 	return typeList;
 }
 
-EXPORT std::string libxbee::XBee::mode(void) {
+EXPORT std::string libxbee::XBee::mode(void) const {
 	xbee_err ret;
 	const char *mode;
 	
@@ -131,17 +143,17 @@ EXPORT std::string libxbee::XBee::mode(void) {
 	return std::string(mode);
 }
 
-EXPORT void libxbee::XBee::setLogTarget(FILE *f) {
+EXPORT void libxbee::XBee::setLogTarget(FILE *f) const {
 	xbee_err ret;
 	
 	if ((ret = xbee_logTargetSet(xbee, f)) != XBEE_ENONE) throw(ret);
 }
-EXPORT void libxbee::XBee::setLogLevel(int level) {
+EXPORT void libxbee::XBee::setLogLevel(int level) const {
 	xbee_err ret;
 	
 	if ((ret = xbee_logLevelSet(xbee, level)) != XBEE_ENONE) throw(ret);
 }
-EXPORT int libxbee::XBee::getLogLevel(void) {
+EXPORT int libxbee::XBee::getLogLevel(void) const {
 	xbee_err ret;
 	int level;
 	


### PR DESCRIPTION
- Declare all member functions that don't alter the object as const.
- Use "const string&" instead of "string" in member function parameters. There is no need to do the extra copy.
- Use const pointer parameters whenever possible.